### PR TITLE
Ported content from rcos/intro

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,7 @@
+**Description of Issue:**
+
+Please describe your issue here (feel free to delete this text)
+
+**Proposed Solution:**
+
+Please describe your proposed solution here (feel free to delete this text)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+**Resolves Issue:** (add GitHub issue number here)
+
+**Changes in this pull request**:
+-
+-
+-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# RCOS Community Code of Conduct
+In the interest of fostering an open and welcoming environment, RCOS pledges to be an inclusive and harassment-free experience for  all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, educational background, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## General
+The General Code of Conduct applies to all RCOS activity and activity affiliated with any RCOS project online and offline.
+
+### Guidelines
+#### Be respectful and inclusive
+* **Use inclusive language.**  This includes:
+  * Using [gender-neutral or non-gendered language](http://geekfeminism.wikia.com/wiki/Nonsexist_language) where possible
+  * When referring to community members, using their preferred pronouns
+  * In general, avoiding any language that could be considered offensive towards marginalized groups
+* **Respect people's differences.** Examples include:
+  * Being welcoming towards new members
+  * Being open to opposing viewpoints
+  * Being understanding of cultural differences
+  * Making sure your project and any physical spaces your project team may meet are accessible to all members, including members with disabilities
+
+#### Give and be welcoming to constructive feedback
+* **Be constructive and respectful** when giving others feedback. This includes:
+  * Only giving feedback when solicited (e.g. mock presentation, questions section of presentation, request for code review, pull request, etc.)
+  * Keeping all feedback constructive, objective and impersonal
+
+
+### Unacceptable Behaviors
+
+Examples of unacceptable behaviors include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Reporting Incidents
+
+At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+
+### Project Maintainer Responsibilities
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined below.
+
+## RPI-Specific Policies
+
+This section applies to RCOS meetings at RPI, including large group and small group meetings as well as bonus sessions, casual coding sessions, and any project meetings unless otherwise noted.
+
+### Attendance Codes
+Attendance codes are given during all RCOS small group, large group, and bonus sessions. When the attendance code is delivered, go to http://rcos.io, click "Attend", and enter the attendance code so you can be marked as present for the current session.
+
+As much as we value sharing and openness, we also value integrity. Thus, we ask that you do not distribute attendance codes to people who are not currently attending the session. If you are caught distributing attendance codes to people who are absent, **both your attendance code as well as the attendance code(s) you distributed to others will be nullified**.
+
+### Noise
+An important part of RCOS is being able to hear from both fellow RCOS members and guest speakers. We ask that you please refrain from talking or making excessive noise while a speaker is talking as it can be disruptive to the speaker and to your peers.
+
+### During Large Group
+During our large group sessions, we have the following policies.
+
+#### Laptops/Mobile Devices
+RCOS likes to maintain a culture of freedom. If you choose to use your laptop or mobile device during large group presentations, you may do so as long as you are mindful of the people around you. This includes:
+
+* Muting all audio
+* Not participating in audio or video calls
+* Ensuring any material that may be visible on your screen is SFW (safe for work)
+* Keeping mobile devices on "Silent" or "Vibrate"
+* Using your device's keyboard instead of a mechanical keyboard
+
+In addition, some speakers may ask audience members to close all laptops and put away all mobile devices. If a speaker does so, please respect their request.
+
+If you absolutely must take a phone call, you can exit the lecture hall to make/take a phone call. If you need to call emergency services for any reason, you may remain in the room while you make the call.
+
+If you use assistive technology due to a documented disability or injury, or you use a medical device that may make noise or looks similar in appearance to a mobile phone or laptop, **please touch base with a faculty member ASAP**. This will remain confidential.
+
+### Consequences of Code of Conduct Violations
+If you violate the RCOS Community Code of Conduct, appropriate consequences will follow at the discretion of faculty. These may include:
+
+* A verbal or Slack warning from a mentor or coordinator
+* A written warning from a faculty member
+* A request to edit or delete any blog posts, code, comments, issues, pull requests, milestones, wiki pages, social media posts, etc. that violate the Code of Conduct
+* If the violation occurred at an RCOS event or meeting, you may be removed from the event or meeting. This will be marked as an unexcused absence regardless of whether or not you already entered an attendance code, and you will not be able to make up this absence by attending a bonus session.
+* In severe and repeated violations, you may be removed from RCOS entirely. If you are taking RCOS for credit, you will receive a failing grade for the semester.
+
+## License and Attribution
+
+This Code of Conduct has been adapted with modifications from the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/). This Code of Conduct, like everything RCOS does, is open source and can be found in our [intro](https://github.com/rcos/intro) repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# handbook
-Organization documentation for RCOS 
+# Welcome to RCOS
+<!-- Organization documentation for RCOS -->
+
+
+
+<!-- # RCOS Intro -->
+
+<!-- This repository exists to introduce each new semester of RCOS. The presentation folder contains a [reveal.js](https://github.com/hakimel/reveal.js) presentation that is shown on the first day of class. This README contains all the information in the presentation in a bit more detail. -->
+
+<!-- This is intended to be a thorough, living document detailing the organizational practices of RCOS at every level. If you find a problem or something that you'd like to dispute, please [open an issue](https://github.com/rcos/handbook/issues/new). -->
+
+<!-- # What is RCOS? -->
+
+The [Rensselaer Center for Open Source](https://rcos.io) (RCOS for short) is a large community of open source developers who develop code to solve societal problems. The goal of RCOS is to provide a creative, intellectual and entrepreneurial outlet for students to use the latest open-source software platforms to develop applications that solve societal problems.
+
+Internally, it is often fondly said that "RCOS is anarchy", as there are very few rules and projects are free to organize and contribute however they want.
+
+# What does RCOS do for you?
+
+RCOS offers a unique, open-ended learning experience. In RCOS, a student can contribute to existing open source efforts, learn a new technology, find a development team, and work on their "passion projects".
+
+RCOS offers a huge community of open source developers skilled in nearly any platform, framework or language. Generally we communicate over [our slack](https://rcos.slack.com), where answers to questions and insightful discussions in a wide variety of topics can be explored.
+
+RCOS is offered for credit at RPI and fulfills a 4000 level technical elective.
+
+# How to join RCOS
+
+If you're an RPI student, hop in on our first meeting of the semester or join [our slack](https://rcos.slack.com) and message a faculty coordinator (@mskmoorthy or @turnew2).
+
+If you're looking to get involved with RCOS as a member outside of RPI, email a [coordinator](coordinators@rcos.io) to get setup on the [rcos slack](#slack). In the meantime, you can create an account and fill in your profile on [Observatory](#observatory).
+
+Built with [Docsify](https://docsify.js.org)
+

--- a/_coverpage.md
+++ b/_coverpage.md
@@ -1,0 +1,17 @@
+<!-- _coverpage.md -->
+
+<!-- ![Logo](https://raw.githubusercontent.com/aeksco/intro/docsify/slides/assets/logo.png) -->
+
+# RCOS Handbook <small>version 0.1</small>
+
+> The Rensselaer Center for Open Source
+
+<!-- * Simple and lightweight (~19kB gzipped) -->
+<!-- * No statically built html files -->
+<!-- * Multiple themes -->
+
+<!-- [GitHub](https://github.com/QingWei-Li/docsify/) -->
+<!-- [Get Started](#docsify) -->
+
+<!-- background color -->
+<!-- ![color](#ffffff) -->

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,57 @@
+* Overview
+  * [Welcome to RCOS](README.md)
+  * [Code Of Conduct](docs/overview/code_of_conduct.md)
+  * [Sponsors](docs/overview/sponsors.md)
+  * [Contact](docs/overview/contact.md)
+
+* Getting started
+  * [Join RCOS](docs/membership/join_rcos.md)
+  * [Project Pitch](docs/membership/speed_dating.md)
+  * [Speed Dating](docs/membership/speed_dating.md)
+  * [Code Of Conduct](CODE_OF_CONDUCT.md)
+
+* Events
+  * [Large Group Meetings](docs/events/large_group_meetings.md)
+  * [Small Group Meetings](docs/events/small_group_meetings.md)
+  * [Casual Coding Sessions](docs/events/casual_coding_sessions.md)
+  * [Code Jams](docs/events/code_jams.md)
+  * [Hackathons](docs/events/hackathons.md)
+  * [RCOS Expo](docs/events/expo.md)
+
+* Grading
+  * [Overview](docs/grading/README.md)
+  * [Rubric](docs/grading/rubric.md)
+  * [Status Updates](docs/grading/status_updates.md)
+  * [Flex](docs/grading/flex.md)
+
+* Teams
+  * [What are RCOS Teams?](docs/teams/README.md)
+  * [Public Relations](docs/teams/public_relations.md)
+  * [Sponsorship](docs/teams/sponsorship.md)
+  * [Outreach](docs/teams/outreach.md)
+  * [Event Planning](docs/teams/event_planning.md)
+  * [Professional Development](docs/teams/professional_development.md)
+
+* Mentoring
+  * [What are Mentors?](docs/mentoring/README.md)
+  * [Training](docs/mentoring/README.md)
+
+* Coordinating
+  * [What are Coordinators?](docs/coordinating/README.md)
+  * [First Week Agenda](docs/coordinating/agenda.md)
+
+* Faculty Advisor
+  * [What are Faculty Advisors?](docs/coordinating/README.md)
+
+* Student Resources
+  * [Code Of Conduct Template](docs/resources/code_of_conduct_template.md)
+  * [Presentation Slides](docs/resources/slides.md)
+  * [Tech Recommendations](docs/resources/README.md)
+
+* Press Resources
+  * [Brand Standards](docs/resources/brand_standards.md)
+  * [Press Kit](docs/resources/press_kit.md)
+
+* RCOS Handbook
+  * [Overview](docs/handbook/README.md)
+  * [Contributing](CONTRIBUTING.md)

--- a/docs/coordinating/README.md
+++ b/docs/coordinating/README.md
@@ -1,0 +1,1 @@
+README.md

--- a/docs/coordinating/agenda.md
+++ b/docs/coordinating/agenda.md
@@ -1,0 +1,64 @@
+# First Two Weeks Agenda
+
+The first two weeks is an extremely important time to get new students acquainted with RCOS, old students updated on any changes in structure/leadership, assigning mentors and a handful of other tasks. This is the most important time for the coordinators to be "on top of things".
+
+## Before the First Meeting
+Prior to the first meeting, mentors and new coordinators should be chosen. Any planned changes should be reflected in the relevant documentation and/or presentations. The coordinators should meet to plan and make sure all administrative affairs are in order.
+
+## Outline
+All of the following details need to be worked out within the first two weeks
+* RCOS Concepts
+  - History Reviewed
+  - Structure, Grading and Motivations introduced
+  - Sponsors introduced
+  - Small groups introduced
+  - Semester Goals introduced
+  - Presentation rules and guidelines
+* Old Projects Pitched
+* New Projects Pitched
+* Project Matching
+* URP/4UR (School Paperwork) Filled Out
+
+## First Meeting
+
+The first meeting is to be held on the first Tuesday or Friday of classes, whichever comes first.
+
+The first meeting begins with the [rcos introduction slides](https://rcos.github.io/intro), presented by the student coordinators. The slides go through the stucture of RCOS and how to participate. A faculty coordinator will then give a talk on the history of RCOS, and briefly explain some administrative details.
+
+After the intro talk, mentors are announced and given the chance to introduce themselves. Mentors should say a few sentences about themselves and what experience they have.
+
+It is stated that a select few projects will pitch at the second meeting, and all other projects will pitch on the third meeting (giving time for people who are new to RCOS to join the project). Pitch slides are collected by a coordinator until 11:59PM the night before the third meeting.
+
+Existing projects are reminded to submit proposals. Existing projects are asked to fill out a form expressing their small group mentor/technology preference.
+
+## Second Meeting
+
+At the second meeting, the expectations of working on a project for credit are defined. The rubric is explained with emphasis on changes / improvements from the previous year based on feedback from students and mentors. Coordinators should be careful not to sound stringent or cold, while making clear that working on a project for credit does require a commitment and the students' best effort.
+
+After expectations are defined, students are reminded how to pitch their projects the following meeting, and a select few projects will then give their pitches. These are typically the most well-established projects, projects that need more time to pitch, or sponsored / external projects. If needed, some such projects may pitch at the third meeting as well.
+
+## Third Meeting
+
+The third meeting is dedicated solely to project pitches. Each pitch should be no more than one minute long, although exceptions are sometimes made for 'special' projects.
+
+Additional information should be kept to the minimum. Students should be encouraged to get in touch with project leaders and mentors for help picking a project, and should be reminded of the URP form deadlines.
+
+## Fourth Meeting
+
+The fourth meeting has two parts that occur simultaneously: project 'Speed Dating' and proposal approval. The mentors should be split evenly between the two events, with each occuring in its own room. Finding a project can be very nervewracking for newcomers, so project speed dating is intended to ensure every student finds a project.
+
+In one room, every project that is looking for more group members should have a representative present to talk to potential group members. The representative should have a printed copy of their pitch slide to identify themself. Every student that does not yet have a project will be present, and will be able to talk to the project representatives and find a project that matches their interest. Mentors should be present to guide students who appear lost or anxious, and to make sure each project gets members. Once students have selected their project, or if they already have a project, they should go to the second room.
+
+In the second room, mentors should be present to look over student's proposals and approve them. If a proposal does not meet the guidelines, mentors should assist the project members in modifying their proposal.
+
+Every for-credit student must have a project with an approved proposal by the end of the fourth meeting.
+
+## Prior to the Fifth Meeting
+
+Mentor groups should selected and rooms should be assigned prior to the fifth meeting. Each mentor group should have its own room. Projects should be distributed amongst mentor groups as evenly as possible. Projects should be assigned to mentors with relevant skill sets so the mentors can best provide technical assistance when needed. All students should be informed of their mentor groups prior to the fifth meeting. If the fifth meeting is a Tuesday, students should report directly to their mentor group.
+
+At least one mentor meeting must occur prior to the fifth meeting. Mentors should be instructured to ensure that mentees:
+1. Are on [rcos.io](https://rcos.io).
+2. Are on [rcos.slack.com](https://rcos.slack.com)
+
+Additionally, general mentoring strategies and tips should be discussed. Any larger goals for the year should be made clear and a schedule for mentor meetings should be set.

--- a/docs/events/casual_coding_sessions.md
+++ b/docs/events/casual_coding_sessions.md
@@ -1,0 +1,6 @@
+# Casual Coding Sessions
+
+## Overview
+- What are Casual Coding Sessions? Office hours, without the heirarchy.
+- Where / when do we meet? (TODO - link to times & locations)
+- Important to note that they count as Bonus Sessions

--- a/docs/events/code_jams.md
+++ b/docs/events/code_jams.md
@@ -1,0 +1,57 @@
+# Code Jams
+
+## Motivation
+
+RCOS holds many events throughout the semester, and affords students many opportunities to learn new technical and non-technical skills. However, we have not specifically focused on fostering our internal community and reaching out to new members as much as we have on other measures of success.
+
+## Goal
+
+We want to create an event that will both build camaraderie among existing members and allow us to reach out to new members and communities. This activity should be accessible to all skill levels by being light-hearted and fun rather than technically challenging. In addition, it should demonstrate that failure is OK and reward participants for trying new things, one of the core principles of RCOS.
+
+## Overview
+
+The RCOS Code Jam will be a semi-competitive fun event where students compete in teams or by themselves on a small programming project. At the end of the event, students will be awarded points based on some criteria. Some of the criteria would be based on the project itself, though most of the criteria will be subjectively based on creativity or other fun aspects. The event itself is meant to be an inclusive meeting to foster internal relationships between current and potential RCOS students.
+
+## Event Structure
+
+The event will take place over a 6-8 hour period, similar to a single-day hackathon. At the beginning of the event, participants are provided with a prompt. This prompt will be chosen from a list of potential prompts by popular vote of the participants. This prompt should be sufficiently vague to allow much room for interpretation, but focused enough to allow us to compare solutions. The prompt should ask participants to solve a problem, but the interpretation of the problem itself and how it should be solved is up to the participants. This will (hopefully) allow participants to apply whatever skills they possess without feeling overwhelmed or unqualified. Solutions may take the form of a web service, a video game, a visualization, an interactive command line tool, or anything the participants can think of. Participants may work individually or in small groups. Lunch, snacks, and beverages will be provided for all participants.
+
+## Potential Projects
+
+Participants will vote at the start of the event on which prompt they would like to solve, but all participants should follow the same prompt. Some potential prompts include (details to come):
+
+- Build a sandwich factory
+- Emoji Recomremender 😄
+- Manage a farm
+- Plan a vacation
+- Build a railroad
+- An absurd campus-lore related challenge
+- Place like 10 more ideas here
+
+## Mentor Duties
+
+Mentors should be present and floating around the event. Mentors should help participants form teams, decide what they want to do, and provide inspiration tailored to the specific skills of each participant as needed. Mentors should introduce participants to relevant technologies they might find useful and accessible based on their background and what they want to accomplish. Some ideas for potential solutions should be pre-prepared and suggested to struggling groups as needed.
+
+A larger number of mentors will be needed towards the beginning as less experienced participants are figuring out what they want to do. As the event progresses fewer mentors should be needed so mentors may choose to participate themselves or leave if they have other commitments, as the event will take most of the day.
+
+Participants are encouraged to talk to mentors even if they don’t require help as mentors may be able to offer an “easter egg” for the event (and potentially for a secret judging category at the end).
+
+## Judging
+
+Judging will take place at the end of the event. Each team will have five minutes to explain to the group what they did and give a short demo. Judges should take notes on each presentation. Rather than having ranking winners, team will be awarded for excelling in various specific areas. Many of the awards should be less serious in nature. After everyone has presented, the judges will leave the room and decide the winners for each category. Small prizes should be given accordingly.
+Award categories should be chosen to allow for
+Award categories may include, but are not limited to:
+
+
+- How well the solution addresses the prompt
+- Creativity and uniqueness of the solution
+- Interesting or unexpected use of existing technologies
+- Sheer Ridiculousness 😝
+- Best design for Open Source
+- Documenting your project for others to use
+- Choosing an Open Source License 🤗 🙌 +1!
+- Most / least efficient
+- Most input received from mentors
+- Vaporware award
+- Best documentation for a non-existent project
+- Altruism

--- a/docs/events/expo.md
+++ b/docs/events/expo.md
@@ -1,0 +1,9 @@
+# RCOS EXPO
+- Opportunity for the RCOS community to interface with the broader RPI community
+- One-day event, weekend?
+- Posters, talks, guest speakers, sponsors
+- Opportunities for longer project-specific presentations
+- Reserve DCC for a Saturday?
+
+
+TODO - flesh out this document.

--- a/docs/events/hackathons.md
+++ b/docs/events/hackathons.md
@@ -1,0 +1,4 @@
+# Hackathons
+
+## Overview
+- [HackRPI](https://hackrpi.com)

--- a/docs/events/large_group_meetings.md
+++ b/docs/events/large_group_meetings.md
@@ -1,0 +1,30 @@
+# Large Group Meetings
+
+## Overview
+- What are large group meetings?
+- Where / when do we meet?
+
+## Announcements
+Meetings begin with announcements. It's an opportunity for the coordinators to introduce the meeting's speakers & presentations. Any RCOS member is welcome to make an annoucement at the beginning of a meeting (in fact, it's encouraged!).
+
+## Guest Speakers
+RCOS welcomes guest speaksers to present their work or research and how it encorporates open-source software.
+- TODO - add list of past guest speakers
+- TODO - add a link to contact page (i.e. `If you're interesting in being a guest speaker, please contact xyz@rcos.io`)
+
+## Project Presentations
+  - 1 required per-team, per-semester
+  - Enforce time limits, structure for presentations
+
+## Team Presentations
+
+RCOS Teams should present once per semester with an overview of their goals and an update on their progress.
+
+## Lightning Talks
+  - first/second/third/fourth friday of every month
+  - Enforce format (i.e. 1 slide, 2 minute max)
+
+## Sick Picks
+  - first/second/third/fourth friday of every month
+  - share some tech you've been using
+  - Enforce format (i.e. 1 slide, 2 minute max)

--- a/docs/events/small_group_meetings.md
+++ b/docs/events/small_group_meetings.md
@@ -1,0 +1,17 @@
+# Small Group Meetings
+
+## Overview
+- What are small group meetings?
+- Where / when do we meet? (TODO - link to times & locations)
+
+## Announcements
+Meetings begin with announcements.
+
+## Stand Up
+Each project has an opportunity to give their small-group a brief update on their progress over the past week. Follows SCRUM format.
+
+## Team Presentation Review
+RCOS Teams should present their presentation during small-group the Tuesday before they present at the Large Group Meeting. Presentation Review provides students an opportunity to rehearse their presentation and receive feedback before presenting to the broader RCOS community.
+
+## Open Hacking
+The remaining time in the small group meetings is dedicated to working onyour project. This time allocation enables mentors to check in on each project and help resolve problems and guide their ongoing work.

--- a/docs/grading/README.md
+++ b/docs/grading/README.md
@@ -1,0 +1,87 @@
+# Grading Requirements
+
+RCOS is largely a self-guided class, which can make grading difficult. Instructors assign appropriate grades using utilities such as [Observatory](https://rcos.io/) to track open source contributions and community involvement.
+
+The following grading criteria are designed to help you succeed as an RCOS student and in the open source community. Generally speaking, if you're contributing to the community and/or making valuable open-source contributions you'll receive a high grade in RCOS.
+
+## Project Management
+
+### Proposal
+
+Each project must start with a proposal which will serve as a plan and contract. Your proposal should describe a set of well defined milestones with planned dates of completion. Details on milestone requirements are described in the [Milestones and Issues](#Milestones-and-Issues) section.
+
+The proposal and milestones must be approved by a mentor at the start of the semester. However, it is important to remember that the proposal is a living document. Plans often change, and that is OK.
+
+### Milestones and Issues
+
+You must use GitHub Milestones and Issues to define and track progress of your project.
+
+Milestones are specific points along the project timeline. Milestones are designed to signal the start and end of phases of the project. Milestones are generally over-arching goals and should define the project's direction.
+
+Issues are small increments of your project. They should have clear acceptance criteria, and should contain enough background information that someone completely new to the project could easily understand the task. Each issue should belong to a milestone. Common issue topics include but aren't limited to:
+- New features
+- Designs
+- Research goals
+- Architecture changes
+- Project management tasks
+- Business development
+- Documentation
+- Community outreach
+- Testing
+
+Project members must keep their milestones and issues up to date as the project progresses. This includes updating milestones and issues as the project evolves. Project members should comment on issues to ask questions, report progress, and have discussions regarding the issue.
+
+Each team member should contribute to at least 3 milestones, and multiple team members can of course collaborate on any given milestone. These are suggested values and many groups may find different numbers to be appropriate.
+
+Progress for each milestone must be thoroughly documented in one or more blog posts. See [Blog Posts](#blog-posts) for more information. If a milestone is not a functional change, there should be a greater focus on documentation to appropriately convey the work that was done.
+
+If you are not sure how to best divide up your project into milestones and issues, please ask a mentor for assistance.
+
+## Documentation
+
+Projects should be well documented. Documentation can take many forms. A README and an [OSI approved license](https://choosealicense.com/) are mandatory. The README should include a summary of the project, instructions for contributing, and any other information needed to develop for and use the project.
+
+Additional documentation (other than a README and blog posts) is required. Examples of additional documentation include but are not limited to:
+- Business plans & reports
+- UML diagrams
+- API documents
+- User manuals
+- FAQs
+- Setup guides
+- Troubleshooting information
+
+The use of a wiki is strongly encouraged. Creating a static project site can help you organize your various forms of documentation and provide excellent exposure for your project.
+
+If you are unsure how to properly document your project, please consult your mentor for advice early on.
+
+### Blog Posts
+
+Blog posts should be informative, and are often status updates about your project. They can also be more general or written in the form of a guide or tutorial. Blog posts that may help another developer solve a problem that you have solved are extremely valuable to the open source community. In general you should write blog posts that you would want to read and that you would find useful!
+
+Blog posts are also a good way to explain the high level goals of a project, to indicate that a project is struggling (someone in RCOS might be able to help!) or just to document tasks that don't fall easily into other categories.
+
+The minimum requirement for blog posts is one per milestone plus one at the start and end of the semester, but you are strongly encouraged to do more. Blog early and blog often!
+
+## Presentations and Community Involvement
+
+Each project group is required to give one large group presentation. Presentations should be well prepared and rehearsed in the presence of a mentor for feedback. See [RCOS presentations](http://rcos.github.io/intro/presentations#/) for more details.
+
+### Tech Talks & Bonus Sessions
+
+In addition to the large group project presentation, each member is required to either give one large group tech talk, host a bonus session, or alternatively attend a bonus session. A bonus session is simply any event hosted outside of the normal RCOS hours. Upperclassmen and more senior members are encouraged to give tech talks for the benefit of the RCOS community. All members are encouraged to attend bonus sessions. A bonus session attended in lieu of hosting a bonus session or giving a tech talk cannot also count as an attendence makeup.
+
+## Attendance
+
+Being part of the RCOS community means seeing what RCOS members are doing, giving feedback, and learning from tech talks and guest speakers. Attendence is required and is taken on Tuesdays and Fridays via Observatory.
+
+Unexcused absences can be made up by attending bonus sessions. Generally bonus sessions are unique, long or workshop-style tech talks, an RCOS hackathon, or an optional RCOS session. Pay attention in the large group meeting to hear bonus sessions announced.
+
+A student can have two unexcused absences before their grade is affected or make-ups are needed.
+
+## External Contributions
+
+Contribute to something outside of RCOS or help out another group with an issue! External contributions are encouraged as it allows RCOS to give back to the larger open source community. The project you're contributing to should be used by a significant number of people outside of RPI.
+
+Within RCOS, we also want to generate a community of helping other projects and making your project more friendly to outside contributors. If you're doing your external contributions to another RCOS project, it must be a project that you have not previouly worked on and you must communicate with the project through GitHub issues, PRs, and code reviews.
+
+External contributions are strongly encouraged but are not required. With the approval of a mentor, a significant external contribution can take the place of a ~~single~~ [milestone requirement](#milestones).

--- a/docs/grading/flex.md
+++ b/docs/grading/flex.md
@@ -1,0 +1,17 @@
+# Flex Grading Requirements
+
+## Overview
+- What is flex? More diverse opportunities to fulfill grading requirements in RCOS.
+- Students can pick and choose options to fulfill this aspect of their grading requirement
+
+## Flex Options
+- RCOS Team positions
+- Hosting an event
+- Mentoring
+- Coordinating
+- Lightning Talks
+- Sick Picks
+- On-going project-specific blog
+- External Contributions
+- Bonus Sessions
+- RCOS EXPO

--- a/docs/grading/rubric.md
+++ b/docs/grading/rubric.md
@@ -1,0 +1,43 @@
+# Grading Rubric
+
+TODO - this document must be refactored to include the other optional.
+
+Although RCOS is a team sport, grading is done on the individual member. Make sure you meet the requirements, including the requirements on the project itself such as the README, License and other forms of documentation.
+
+**If you find this rubric to be incompatible with your project, or you believe that it will significantly hinder or not accurately represent your progress, please let a coordinator or faculty member know as adjustments and exceptions can be made.**
+
+## 50% - Contributions and Planning
+| Grade | Description |
+|-|-|
+| **A** | Makes meaningful contributions to several milestones. Student is active on GitHub and Slack and makes excellent use of issue tracking and project management systems. Student communicates failures and development barriers to their team and mentors, and makes their best effort to overcome challenges. |
+| **B** | Makes meaningful contributions to several milestones, but may be slightly lacking in communication and/or planning requirements, or may not make good use of issue tracking / project management systems. |
+| **C** | Makes too few contributions and does not ask for help when needed. Student makes little to no use of issue tracking and project management systems, and does not communicate well with team members or mentors. |
+| **D** | Makes almost no meaningful contributions and makes little effort to communicate with team members and mentors. |
+| **F** | Makes no visible effort to contribute to their project or communicate with their team and mentors. |
+
+## 20% - Documentation
+| Grade | Description |
+|-|-|
+| **A** | Makes frequent, high caliber blog posts documenting each issue they work on and several problems they solve. Project has an OSI approved license, a helpful README, has additional documentation that is of quality and value. |
+| **B** | Makes blog posts that may be too few or brief OR project may not have may not have much additional documentation. |
+| **C** | Makes only a few or low quality blog posts, OR project may have little other documentation. |
+| **D** | Makes few blog posts of little to no value and does not contribute to other forms of documentation. |
+| **F** | Makes no blog posts and contributes no effort toward documenting the project. Project does not have a meaningful README or license. |
+
+## 15% - Presentations and Community Involvement
+| Grade | Description |
+|-|-|
+| **A** | Participates in large group presentation and demonstrates a knowledge of what they worked on; is well prepared and clearly rehearsed. Hosts a well prepared and useful tech talk or bonus session OR attends the requisite bonus session. |
+| **B** | Makes a reasonable effort to participate in presentation and is at least somewhat prepared. Hosts a tech talk or bonus session OR attends the requisite bonus session. |
+| **C** | Is unprepared for presentation or does not participate heavily. Hosts a tech talk or bonus session OR attends the requisite bonus session. |
+| **D** | Makes little effort to participate in presentation and does not host tech talk, bonus session, or attend bonus sessions. |
+| **F** | Makes no effort to participate in presentation or does not attend. Does not host tech talk, bonus session, or attend any bonus sessions. |
+
+## 15% - Attendance
+| Grade | Description |
+|-|-|
+| **A** | Misses no more than two meetings and makes up any unexcused absences by attending bonus sessions. |
+| **B** | Attends most meetings and makes up most unexcused absences. |
+| **C** | Repeatedly misses meetings or does not make up unexcused absences. |
+| **D** | Misses many meetings and does not attempt to make up unexcused absences. |
+| **F** | Makes no effort to regularly attend meetings. |

--- a/docs/grading/status_updates.md
+++ b/docs/grading/status_updates.md
@@ -1,0 +1,22 @@
+# Status Updates
+
+## Overview
+
+**What are Status Updates?**
+
+  Status Updates were introduced to enable mentors and coordinators to better gauge each student's on-going progress during the semester. This solution replaces the previous requirement of 4 Blog Posts per-semester.
+
+**Why were Status Updates introduced?**
+
+  Status Updates were introduced to enable mentors and coordinators to better gauge each student's on-going progress during the semester. This solution replaces the previous requirement of 4 Blog Posts per-semester.
+
+## Requirements
+- Write one status update every other week
+- Status Update should include links to any work
+  - GitHub Issues
+  - GitHub Pull-Requests
+  - Blog Posts (project or team)
+  - Lightning Talks
+  - Sick Picks
+  - Presentations
+  - Bonus Sessions

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,10 @@
+# RCOS Handbook
+
+- What is it?
+- Why do we have it?
+- How to contribute?
+- Guidelines
+- Checks and balanaces
+- Contributing
+
+### If it isn't documented, it doesn't exist.

--- a/docs/membership/join_rcos.md
+++ b/docs/membership/join_rcos.md
@@ -1,0 +1,25 @@
+# How to join RCOS
+
+If you're an RPI student, hop in on our first meeting of the semester or join [our slack](https://rcos.slack.com) and message a faculty coordinator (@mskmoorthy or @turnew2).
+
+If you're looking to get involved with RCOS as a member outside of RPI, email a [coordinator](coordinators@rcos.io) to get setup on the [rcos slack](#slack). In the meantime, you can create an account and fill in your profile on [Observatory](#observatory).
+
+## Github
+
+[Github](https://github.com/) is where most RCOS projects are stored and collaborated on within. You will need to create an account and eventually create or join a project.
+
+## Observatory
+
+[Observatory](https://rcos.io) is RCOS's open source project management platform. Every RCOS member is required to have an observatory account, it's through this platform that you can write blog posts, record your attendance and see other RCOS projects.
+
+## Slack
+
+[Slack](https://rcos.slack.com) is the primary communication platform for RCOS. Each team in RCOS has a Slack channel where they can coordinate meetings and manage the project.
+
+## Git
+
+[Git](https://git-scm.com/) is a version control/collaboration system that is extremely popular among open source projects. To contribute in RCOS, you WILL need to learn to use git (it's not that bad). Try taking [github's git tutorial](https://try.github.io/levels/1/challenges/1).
+
+## Finding an Open Source project to contribute to
+
+[Github Explore](https://github.com/explore) allows you to explore Github and find awesome open source projects to contribute to. Spend a good amount of time finding a project that you like. Don't be intimidated! Many projects that seem very complicated are actively looking for new contributors and will give you "easy" issues to get started. You'll learn fast! Feel free to tackle issues as a team.

--- a/docs/membership/speed_dating.md
+++ b/docs/membership/speed_dating.md
@@ -1,0 +1,3 @@
+# Speed Dating
+
+Finding a team in RCOS isn't a requirement, but can often make RCOS easier for everyone. There are many ways to find a team but the easiest way is to look for teams during RCOS Pitch Days (the day when people say what projects they're going to be working on). If you're still looking for a team after pitch day, talk to your mentor or look for other groups in your small group.

--- a/docs/mentoring/README.md
+++ b/docs/mentoring/README.md
@@ -1,0 +1,42 @@
+# Mentors
+
+## Mentors
+
+Mentors are the life blood of RCOS, a mentor can help you with technical problems, show
+you where/how to find help for your project, and help you find a new project etc.
+
+### Mentor Responsibilities
+- Help point students to what they need to do/where they need to go within RCOS
+- Make sure your mentees are on their schedule OR have documented reasons to be off their schedule.
+- Set up whatever organization/goal structure you feel is best for helping students be successful with their open source contributions; this is what gives a small group personality.
+- In general, help maintain the freedom and culture of RCOS and encourage open source contribution.
+
+### How to be a good mentor
+- Help mentees to reach their own goals
+- Talk directly to projects and mentees, understand what their project is and where you can help
+- Share ideas and contribute to development of RCOS as a whole- as long as you're monitoring the #mentors slack channel you should opportunities to contribute.
+
+### Things Mentors should Know
+- Names and channels for referring mentees to coordinators or faculty
+- How to direct mentees to the [rcos intro slides](http://rcos.github.io/intro/#/)
+
+## Student Coordinators
+
+Student coordinators are mentors that organize the first couple weeks as well
+as the large group meetings. If you're having an issue and your mentor can't
+point you in the right direction, a coordinator will be able to direct you
+towards another mentor, faculty or help you directly.
+
+## External Mentors
+
+External mentors are mentors that help projects remotely. External mentors serve a different role than regular student mentors.
+
+In particular, they get the following exceptions:
+- External mentors don't need to attend small and large group meetings
+- External mentors don't need to understand the logistics of RCOS (students should ask their student mentors for this)
+
+External mentors have their own sets of requirements, usually they provide a subset of the following responsibilities...
+- Get students involved with industry or personal projects outside of RCOS
+- Assist students with problems with a technology stack
+- Introduce students to new technologies
+- Provide advice to students regarding open source technologies

--- a/docs/mentoring/README.md
+++ b/docs/mentoring/README.md
@@ -1,7 +1,5 @@
 # Mentors
 
-## Mentors
-
 Mentors are the life blood of RCOS, a mentor can help you with technical problems, show
 you where/how to find help for your project, and help you find a new project etc.
 

--- a/docs/overview/code_of_conduct.md
+++ b/docs/overview/code_of_conduct.md
@@ -1,0 +1,5 @@
+# RCOS Community Code of Conduct
+
+Our **Community Code of Conduct** outlines some common ground rules all RCOS members are expected to abide by in order to make RCOS an inclusive experience for everyone. You can find the RCOS Community Code of Conduct [here](https://github.com/rcos/intro/blob/master/docs/code_of_conduct.md).
+
+In addition to following the Community Code of Conduct, we strongly suggest that your project's repository includes a Code of Conduct as well. You can find a Code of Conduct template for your project that includes an abbreviated version of our Code of Conduct as well as space for any project-specific ground rules [here](https://github.com/rcos/intro/blob/master/docs/project_coc_template.md). In addition, Github has instructions on including a Code of Conduct in your project [here](https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/).

--- a/docs/overview/contact.md
+++ b/docs/overview/contact.md
@@ -1,0 +1,11 @@
+# Contact
+
+TODO - contact information goes here.
+
+Information to include:
+- Social Media Links
+- Email Addresses
+- List of Faculty Advisors w/ contact information
+- Link to RCOS GitHub
+- Link to RCOS Mozilla Campus Network
+- Afilliated organizations - RPISec, UPE, HACK-RPI, else?

--- a/docs/overview/sponsors.md
+++ b/docs/overview/sponsors.md
@@ -1,0 +1,9 @@
+# Sponsors
+
+TODO - information regarding sponsors goes here.
+
+Information to include:
+- list of current sponsors
+- how to become a sponsor
+- how to donate to RCOS
+- contact information

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -1,0 +1,39 @@
+# Helpful Resources
+
+## Open Source
+
+[Intro to Open Source Class Materials](https://github.com/rcos/CSCI2963-01-Spring2017)
+
+[Github Tutorial](https://try.github.io/levels/1/challenges/1)
+
+[Open Source Initiative](https://opensource.org/)
+
+## Python
+
+[Getting Started](https://www.python.org/about/gettingstarted/)
+
+[Python Tutorial](https://docs.python.org/3/tutorial/)
+
+## Java
+
+[Introduction to Java](https://www.ibm.com/developerworks/java/tutorials/j-introtojava1/index.html)
+
+## JavaScript
+
+[W3schools Introduction to Javascript](https://www.w3schools.com/js/js_intro.asp)
+
+[Mozilla Introduction to Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Introduction)
+
+[JSFiddle](https://jsfiddle.net/)
+
+## HTML
+
+[W3schools](https://www.w3schools.com/html/)
+
+## C++
+
+[C++ Tutorial](http://www.cplusplus.com/doc/tutorial/)
+
+## Docker
+
+[Katacoda](https://www.katacoda.com)

--- a/docs/resources/brand_standards.md
+++ b/docs/resources/brand_standards.md
@@ -1,0 +1,9 @@
+# Brand Standards
+
+Information regarding our brand standards
+
+- Links to graphical assets (`png`, `svg`, `jpg`, etc.)
+- Correct pronunciation (i.e. `ARRR-KOS`, not `ARR-KAUS`)
+- Correct spelling (i.e. `RCOS` is always all-caps)
+- Correct usage of graphical assets (i.e. Red-on-White is okay, Red-on-Black is _not_)
+- Correct usage of organization name (i.e. `The Rensselaer Center for Open Source`, not `Open-Source` or `open-source`)

--- a/docs/resources/code_of_conduct_template.md
+++ b/docs/resources/code_of_conduct_template.md
@@ -1,0 +1,47 @@
+# [Your Project] Code of Conduct
+In the interest of fostering an open and welcoming environment, [your project] pledges to be an inclusive and harassment-free experience for  all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, educational background, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## General
+The General Code of Conduct applies to all [your project]-affiliated activity online and offline.
+
+### Guidelines
+#### Be respectful and inclusive
+* **Use inclusive language.**  This includes:
+  * using [gender-neutral or non-gendered language](http://geekfeminism.wikia.com/wiki/Nonsexist_language) where possible
+  * when referring to community members, using their preferred pronouns
+  * in general, avoiding any language that could be considered offensive towards marginalized groups
+* **Respect people's differences.** Examples include:
+  * Being welcoming towards new members
+  * Being open to opposing viewpoints
+  * Being understanding of cultural differences
+  * Making sure your project and any physical spaces your project team may meet are accessible to all members, including members with disabilities
+
+#### Give and be welcoming to constructive feedback
+* **Be constructive and respectful** when giving others feedback. This includes:
+  * Only giving feedback when solicited (e.g. mock presentation, questions section of presentation, request for code review, pull request, etc.)
+  * Keeping all feedback constructive, objective and impersonal
+
+
+### Unacceptable Behaviors
+
+Examples of unacceptable behaviors include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Reporting Incidents
+
+This project is affiliated with [Rensselaer Center for Open Source](http://rcos.io) (RCOS). At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+
+### Project Maintainer Responsibilities
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined in the RCOS Community Code of Conduct, which can be found under "License and Attribution".
+
+## [Your Project]-Specific Guidelines
+Add any additional ground rules you would like your project team to follow (if any) here.
+
+## License and Attribution
+
+This Code of Conduct has been abbreviated and adapted from the [RCOS Community Code of Conduct](https://github.com/rcos/intro/blob/master/docs/code_of_conduct.md).

--- a/docs/resources/press_kit.md
+++ b/docs/resources/press_kit.md
@@ -1,0 +1,6 @@
+# Press Kit
+
+Information regarding our press kit should be placed here.
+
+- Link to brand standards
+- Link to graphical assets (`png`, `svg`, `jpg`, etc.)

--- a/docs/resources/slides.md
+++ b/docs/resources/slides.md
@@ -1,0 +1,10 @@
+# Slide Decks
+
+TODO - include links to all our slide decks hosted through GitPitch
+
+The document contains links to all presentations used during the first RCOS meetings of the semester.
+
+We currently use [GitPitch](https://gitpitch.com) to generate slide decks from Markdown files in this repository. The presentation slides are maintained in [rcos/handbook/slides](https://github.com/rcos/handbook)
+
+## Presentations
+- [RCOS Intro](https://gitpitch.com/etc/etc)

--- a/docs/teams/README.md
+++ b/docs/teams/README.md
@@ -1,0 +1,16 @@
+# RCOS Teams
+
+TODO - describe the purpose of RCOS Teams
+TODO - document the process of joining a team (sign up forms, no elections!)
+
+Notes
+- Teams are open to RCOS students, faculty, and allumni.
+- Each team should have at least one mentor to manage on-going work
+
+Other Potential Teams:
+- Education
+  - curates materials for self-education in RCOS
+
+- Funds & Equipment
+  - tracks and manages RCOS funds (treasurer, essentially)
+  - tracks and manages RCOS equipment

--- a/docs/teams/README.md
+++ b/docs/teams/README.md
@@ -1,11 +1,13 @@
 # RCOS Teams
 
-TODO - describe the purpose of RCOS Teams
-TODO - document the process of joining a team (sign up forms, no elections!)
+
+RCOS Teams give provide students flexible opportunities to develop their leadership skills and support RCOS as an organization.
 
 Notes
 - Teams are open to RCOS students, faculty, and allumni.
 - Each team should have at least one mentor to manage on-going work
+- TODO - describe the purpose of RCOS Teams
+- TODO - document the process of joining a team (sign up forms, no elections!)
 
 Other Potential Teams:
 - Education

--- a/docs/teams/event_planning.md
+++ b/docs/teams/event_planning.md
@@ -1,4 +1,4 @@
-# Event Planning
+# Event Planning Team
 
 ## Responsibilities
   - hackathons

--- a/docs/teams/event_planning.md
+++ b/docs/teams/event_planning.md
@@ -1,0 +1,7 @@
+# Event Planning
+
+## Responsibilities
+  - hackathons
+  - codejams
+  - casual coding sessions
+  - food & beverage

--- a/docs/teams/outreach.md
+++ b/docs/teams/outreach.md
@@ -1,0 +1,8 @@
+# Outreach Team
+
+## Responsibilities
+  - Find external projects RCOS can contribute to
+  - coordinates & networks with other RPI individuals & organizations
+  - WTG, SWE, RPI-SEC, HACK-RPI
+  - coordinate volunteer efforts for RCOS students
+  - document the process

--- a/docs/teams/professional_development.md
+++ b/docs/teams/professional_development.md
@@ -1,0 +1,6 @@
+# Professional Development
+
+## Responsibilities
+  - organizes CCPD events
+  - interface with recruiters who can offer RCOS students coops/internships
+  - resume events

--- a/docs/teams/professional_development.md
+++ b/docs/teams/professional_development.md
@@ -1,4 +1,4 @@
-# Professional Development
+# Professional Development Team
 
 ## Responsibilities
   - organizes CCPD events

--- a/docs/teams/public_relations.md
+++ b/docs/teams/public_relations.md
@@ -1,4 +1,4 @@
-# Public Relations
+# Public Relations Team
 
 ## Responsibilities
   - RCOS Blog - Editing, curation, etc.

--- a/docs/teams/public_relations.md
+++ b/docs/teams/public_relations.md
@@ -1,0 +1,6 @@
+# Public Relations
+
+## Responsibilities
+  - RCOS Blog - Editing, curation, etc.
+  - Mozilla Open Source Student Network
+  - Social Media

--- a/docs/teams/sponsorship.md
+++ b/docs/teams/sponsorship.md
@@ -1,0 +1,6 @@
+# Sponsorship Team
+
+## Responsibilities
+  - find new RCOS sponsors
+  - maintain relations with existing sponsors
+  - document the process

--- a/index.html
+++ b/index.html
@@ -12,15 +12,17 @@
   <div id="app"></div>
   <script>
     window.$docsify = {
-    //   name: '',
-    //   repo: ''
+      name: 'RCOS Handbook',
+      repo: 'rcos/rcos-handbook',
       loadSidebar: true,
       loadNavbar: false,
       subMaxLevel: 3,
-      basePath: 'https://raw.githubusercontent.com/aeksco/handbook/master',
+      basePath: 'https://raw.githubusercontent.com/rcos/rcos-handbook/master',
       search : [
-        '/',    // => /README.md
-        '/docs' // => /guide.md
+        '/',
+        '/mentoring/',
+        '/grading/',
+        '/teams/'
       ],
 
       maxDepth: 3

--- a/index.html
+++ b/index.html
@@ -2,26 +2,22 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Document</title>
+  <title>RCOS Handbook</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/vue.css">
 </head>
 <body>
   <div id="app"></div>
   <script>
-    // window.$docsify = {
+    window.$docsify = {
     //   name: '',
     //   repo: ''
-    // }
-    window.$docsify = {
       loadSidebar: true,
       loadNavbar: false,
       subMaxLevel: 3,
-      // see https://docsify.js.org/#/configuration?id=base-path
-      // basePath: 'https://github.com/aeksco/handbook',
-      // search: 'auto', // default
+      basePath: 'https://raw.githubusercontent.com/aeksco/handbook/master',
       search : [
         '/',    // => /README.md
         '/docs' // => /guide.md
@@ -31,7 +27,7 @@
 
     }
   </script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+  <script src="https://unpkg.com/docsify/lib/docsify.min.js"></script>
+  <script src="https://unpkg.com/docsify/lib/plugins/search.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     window.$docsify = {
       name: 'RCOS Handbook',
       repo: 'rcos/rcos-handbook',
+      coverpage: true,
       loadSidebar: true,
       loadNavbar: false,
       subMaxLevel: 3,

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    // window.$docsify = {
+    //   name: '',
+    //   repo: ''
+    // }
+    window.$docsify = {
+      loadSidebar: true,
+      loadNavbar: false,
+      subMaxLevel: 3,
+      // see https://docsify.js.org/#/configuration?id=base-path
+      // basePath: 'https://github.com/aeksco/handbook',
+      // search: 'auto', // default
+      search : [
+        '/',    // => /README.md
+        '/docs' // => /guide.md
+      ],
+
+      maxDepth: 3
+
+    }
+  </script>
+  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+</body>
+</html>

--- a/slides/intro/PITCHME.md
+++ b/slides/intro/PITCHME.md
@@ -1,0 +1,314 @@
+# Welcome!
+
+Rensselaer Center for Open Source
+
+---
+
+### About this presentation
+
+[github.com/rcos/intro](https://github.com/rcos/intro)
+
+---
+
+### Other presentations
+- [github.com/rcos/intro/presentations](https://github.com/rcos/intro/presentations)
+- [github.com/rcos/intro/smallgroups](https://github.com/rcos/intro/smallgroups)
+
+---
+
+### Faculty Advisors
+- David Goldschmidt
+- Wes Turner
+
+---
+
+### Faculty Advisors
+- Ada
+- Adrian
+- Ayushi
+- Alex
+
+---
+
+### Spring 2018 Mentors
+- Adeet Phanse
+- Adrian Collado
+- Alexander Schwarzberg
+- Andy Wu
+- Ayushi Mishra
+- Benjamin Wolf
+- Christine Tang
+- Colin Atkinson
+- Jacob Lane
+- Jonathan Caicedo
+- Jonathan Patsenker
+- Kathleen Burkhardt
+- Mark Robinson
+- Matthew Mawby
+- Mike Adams
+- Richi Young
+- Samad Farooqui
+- Sidney Kochman
+- Theo Rice
+- Varun Rao
+- Yuze Ma
+- Zachary Wimer
+
+---
+
+### What is RCOS
+
+RCOS is a creative, intellectual and entrepreneurial outlet for students to use the latest open-source software platforms to develop applications that solve societal problems.
+
+(that's our mission statement)
+
+
+---
+
+### What is RCOS
+
+RCOS is also a venue for open learning and student teaching, as well as exploring the world of open source.
+
+---
+
+### RCOS is anarchy
+
+(but for real)
+
+---
+
+### What does RCOS do for you?
+
+- Unique open-ended learning experience
+- Gain valuable resume boosters
+- Huge community of skilled open source developers
+- Opportunity to work on awesome projects
+- Credit (0-4)
+
+---
+
+### A Brief History of RCOS
+
+[Google Slides](https://docs.google.com/presentation/d/19LBiX2qny7lW9pvMABL85mzl9PmnU-r06DQ4mJh8CiE/edit#slide=id.i0")
+
+TODO - let's port that presentation into markdown
+
+---
+
+### Structure : Members
+
+Every member gets a mentor<br/>
+Ask your mentor first<br/>
+You can always change mentors
+
+---
+
+### Structure : Meetings
+
+Small Group on Tuesday<br/>
+Large Group on Friday<br/><br/>
+Casual Coding Sessions on Wednesday <br/>
+Bonus Sessions (Workshops) on a rolling basis<br/>
+
+---
+
+### Small Groups
+
+
+    - Lead by a small group of mentors
+    - Typically about 20 people to a small group
+    - Attendance is taken (2 absences are excused)
+    - Mentor freedom!
+
+---
+
+### Large Groups
+
+
+    -  Lead by coordinators
+    -  Guest speakers!
+    -  Attendance is taken (2 absencse are allowed)
+    -  One large group presentation per team
+    -  New this semester: Lightning talks!
+
+---
+
+### Casual Coding Sessions
+
+
+    -  Open to all! (not just members)
+    -  Come and work on whatever you want!
+    -  (not just for coding!)
+    -  (Every Wednesday at 4PM)
+    -  Bring your friends!
+
+---
+
+###  Bonus Sessions
+
+    -  Can take the place of a large group attendance
+    -  Scheduled on a rolling basis
+    -  (will be on the calendar)
+    -  More focused workshops, talks on a specific topic
+    -  Mostly student run, some external presenters
+    -  Anyone can host one! Just ask us and we'll add it to the calendar!
+
+---
+
+### Questions?
+
+---
+
+### Getting started at RCOS
+
+---
+
+### Observatory (<a href='http://rcos.io'>rcos.io</h2>
+<p>RCOS's homebrew project management system</p>
+<img src='img/observatory.png'/>
+
+---
+
+### Slack (<a href='http://rcos.slack.com'>rcos.slack/a>)</h2>
+<p>RCOS's primary communication medium</p>
+<img src='img/slack.png'/>
+
+---
+
+### 0-credit SIS course
+<h3>(CRN: 53081 CSCI 4963-01)</h3>
+<p>To reserve our rooms and get a roster</p>
+
+---
+
+### <a href='http://github.com'>GitHub</a>
+<img src='img/github.png'/>
+
+---
+
+### Finding a project
+<a href='https://github.com/explore'>github.com/explore</a><br/>
+<a href='https://rcos.io/projects'>rcos.io/projects</a>
+
+---
+
+### Finding a team (optional)
+
+- Pitch Day
+- Post on Slack
+- Talk to your mentor
+- Project Speed Dating
+
+---
+
+### Start learning git (<a href='http://try.github.io.github.io</a>)</h2>
+<img src='img/learngit.png'/>
+
+---
+
+### Getting Help
+- #helpdesk
+- Slack
+- Mentors (Both internal and external)
+- Coordinators
+- Faculty Members
+
+---
+
+## How to be successful (and get an A!)
+
+---
+
+### Below are guidelines
+
+    - Contribute often
+    - Communicate and document!
+    - Tell us what you're up to (Blog often!)
+    - And be involved!
+    - <a href='https://github.com/rcos/intro'>Read the intro README and GRADING rubric for more details (see How to be Successful...)</a>
+    - <a href='https://github.com/rcos/intro/blob/master/docs/grading.md'>Full Grading Criteria Here</a>
+
+---
+
+### Goals for RCOS 2018
+
+---
+
+###  Collaborate more with other organizations
+
+#### We will be working directly with MOSSN!
+
+---
+
+###  Offer alternative ways to learn and get involved
+#### Not just coding and projects
+
+---
+
+### Strengthen and expand our community
+
+---
+
+### Get more contributions to external projects <smprojects created outside RCOS)</small></h2>
+
+---
+
+###  Have more student talks and bonus sessions!
+
+---
+
+###  Increase longevity of RCOS projects
+
+---
+
+###  What happens next?
+Project pitches next Friday!
+
+- Message @aeksco on slack with your slides by 11pm on Monday (Jan. 22)
+
+- You MUST message Alex with slides!
+
+- Slides MUST be in JPEG format! (Please NO PDF, PPT/X, or Google links!)
+
+- Friday (Jan. 26) - Project speed dating! Find a project!
+
+- DO NOT wait until speed dating to look for a project! Please reach out to at least one prior
+
+- Tuesday (Jan. 30) - Proposal and URPs due!
+
+- Office Hours! Tomorrow (Wednesday the 17th), Wednesday the 24th. Get help finding projects, working on pitches and proposals!
+
+---
+
+### <a href='https://docs.google.com/presentad/18Q-k39aMotBVHTjnHGZRtuLVnS0hngvqTdnuLIvltYg/edit?usp=sharing'>Slide Template</a></h2>
+<img src='img/slide_template.png'/>
+
+---
+
+### What do you do now?
+- Get on rcos.io, Slack and GitHub
+- Sign up on SIS (CRN 53081 CSCI-4963-01)
+- Find a project
+- Email slides
+
+---
+
+### Who do I talk to for &lt;blank&gt;?
+<img src='https://media.giphy.com/media/si7ZWHm50U3T2/giphy.gif'/>
+
+---
+
+### Where are these slides
+<a href='http://rcos.github.com/intro'>rcos.github.com/intro</a>
+
+(rcos.github.com/intro)[http://rcos.github.com/intro]
+
+---
+
+### Thanks!
+
+#### Let's have a great semester!
+
+---
+
+### Questions?


### PR DESCRIPTION
This is the first merge into `rcos/handbook` - still lots of work to be done, but we've got some structure in place to scale out our documentation and some of the changes we'll be making to RCOS for the Fall 2018 semester. Everything in here is subject to change - this is merely a first push to get the ball rolling.

Most of the content from `rcos/intro` has been ported here - but not all of it. I'll be working this weekend to finalize that migration. 