### PR TITLE
Split CoC and bylaws, add more resources, excused absence documentation, expand bylaws

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,9 @@
-# Welcome to RCOS
+# RCOS Handbook
+Organization documentation for RCOS
 
-The [Rensselaer Center for Open Source](https://rcos.io) (RCOS for short) is a large community of open source developers who develop code to solve societal problems. The goal of RCOS is to provide a creative, intellectual and entrepreneurial outlet for students to use the latest open-source software platforms to develop applications that solve societal problems.
+<!-- This repository exists to introduce each new semester of RCOS. The presentation folder contains a [reveal.js](https://github.com/hakimel/reveal.js) presentation that is shown on the first day of class. This README contains all the information in the presentation in a bit more detail. -->
 
-Internally, it is often fondly said that "RCOS is anarchy", as there are very few rules and projects are free to organize and contribute however they want.
+This is intended to be a thorough, living document detailing the organizational practices of RCOS at every level. If you find a problem or something that you'd like to dispute, please [open an issue](https://github.com/rcos/handbook/issues/new).
 
-# What does RCOS do for you?
 
-RCOS offers a unique, open-ended learning experience. In RCOS, a student can contribute to existing open source efforts, learn a new technology, find a development team, and work on their "passion projects".
-
-RCOS offers a huge community of open source developers skilled in nearly any platform, framework or language. Generally we communicate over [our slack](https://rcos.slack.com), where answers to questions and insightful discussions in a wide variety of topics can be explored.
-
-RCOS is offered for credit at RPI and fulfills a 4000 level technical elective.
-
-# How to join RCOS
-
-If you're an RPI student, hop in on our first meeting of the semester or join [our slack](https://rcos.slack.com) and message a faculty coordinator (@mskmoorthy or @turnew2).
-
-If you're looking to get involved with RCOS as a member outside of RPI, email a [coordinator](coordinators@rcos.io) to get setup on the [rcos slack](#slack). In the meantime, you can create an account and fill in your profile on [Observatory](#observatory).
+Built with [Docsify](https://docsify.js.org)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -20,6 +20,7 @@
 * Grading
   * [Overview](grading/README.md)
   * [Rubric](grading/rubric.md)
+  * [Excused Absences](grading/excused_absences.md)
   * [Status Updates](grading/status_updates.md)
   * [Flex](grading/flex.md)
 
@@ -43,9 +44,10 @@
   * [What are Faculty Advisors?](coordinating/README.md)
 
 * Student Resources
-  * [Code Of Conduct](../CODE_OF_CONDUCT.md)
+  * [Code Of Conduct](resources/CODE_OF_CONDUCT.md)
+    * [Bylaws](resources/bylaws.md)
   * [Presentation Slides](resources/slides.md)
-  * [Tech Recommendations](resources/README.md)
+  * [Resources](resources/README.md)
   * [Code Of Conduct Template](resources/code_of_conduct_template.md)
 
 * Branding

--- a/docs/events/hackathons.md
+++ b/docs/events/hackathons.md
@@ -2,3 +2,11 @@
 
 ## Overview
 - [HackRPI](https://hackrpi.com)
+  - Occurs annually in November here at RPI. 
+- [HackTechValley](http://hacktechvalley.com/)
+  - Occurs annually in February.
+- [Major League Hacking](https://mlh.io)
+  - Intercollegiate hackathons that occur around the world.
+    - Don't be afraid to attend a hackathon outside RPI! Many hackathons offer full or partial travel reimbursement, and if you get enough RPI students to register for a hackathon, you may even get a coach bus to come directly to RPI.
+- [Ladies Storm Hackathons](https://github.com/Ladies-Storm-Hackathons)
+  - A community for women and allies involved in hackathons.

--- a/docs/grading/excused_absences.md
+++ b/docs/grading/excused_absences.md
@@ -1,0 +1,19 @@
+# Excused Absences
+
+## Excused Absence Policy
+Excused absences can be given for any of the following:
+* Illnesses/injuries
+* Family emergencies
+* Job interviews
+* Graduate school visits
+* Religious holidays
+* Conferences
+* External hackathons
+* Schedule conflicts with courses, exams, or extracurriculars
+
+The above list is not exhaustive. If you are unsure about what constitutes an excused absence, please reach out to a coordinator or faculty member. However, excused absences will **not** be given if you are removed from a meeting for violating our [Code of Conduct](resources/CODE_OF_CONDUCT.md) or our [Bylaws](resources/bylaws.md).
+
+Excused absences do **not** need to be made up with a bonus session (but you are encouraged to come to bonus sessions regardless!).
+
+## How to Request an Excused Absence on Observatory
+This feature is coming soon!

--- a/docs/grading/rubric.md
+++ b/docs/grading/rubric.md
@@ -41,3 +41,10 @@ Although RCOS is a team sport, grading is done on the individual member. Make su
 | **C** | Repeatedly misses meetings or does not make up unexcused absences. |
 | **D** | Misses many meetings and does not attempt to make up unexcused absences. |
 | **F** | Makes no effort to regularly attend meetings. |
+
+## Addendum - Code of Conduct:
+We want all of you at RCOS to learn in a safe, welcoming, and inclusive environment. The way you conduct yourself at RCOS may have a long-lasting impact on the community, whether that be positive or negative.
+
+Students who go above and beyond to model and encourage positive behaviors outlined in our community Code of Conduct may receive a bonus added to the [Flex](grading/flex.md) portion of their grade and/or additional consideration for leadership positions within RCOS (e.g. task force teams, mentor, coordinator).  
+
+On the other hand, students may be penalized, depending on the severity of the offense, for violating the Code of Conduct. These penalties are given at faculty discretion and may range from a small attendance penalty to an F in the course. Please review the [Code of Conduct](resources/CODE_OF_CONDUCT.md) as well as our [Bylaws](resources/bylaws.md) for more detailed information.

--- a/docs/resources/CODE_OF_CONDUCT.md
+++ b/docs/resources/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# RCOS Community Code of Conduct
+In the interest of fostering an open and welcoming environment, RCOS pledges to be an inclusive and harassment-free experience for  all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, educational background, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+The RCOS Community Code of Conduct applies to all RCOS activity and activity affiliated with any RCOS project online and offline.
+
+## Guidelines
+### Be respectful and inclusive
+* **Use inclusive language.**  This includes:
+  * Using [gender-neutral or non-gendered language](http://geekfeminism.wikia.com/wiki/Nonsexist_language) where possible
+  * When referring to community members, using their preferred pronouns
+  * In general, avoiding any language that could be considered offensive towards marginalized groups
+* **Respect people's differences.** Examples include:
+  * Being welcoming towards new members
+  * Being open to opposing viewpoints
+  * Being understanding of cultural differences
+  * Making sure your project and any physical spaces your project team may meet are accessible to all members, including members with disabilities
+
+### Give and be welcoming to constructive feedback
+* **Be constructive and respectful** when giving others feedback. This includes:
+  * Only giving feedback when solicited (e.g. mock presentation, questions section of presentation, request for code review, pull request, etc.)
+  * Keeping all feedback constructive, objective and impersonal
+
+
+## Unacceptable Behaviors
+
+Examples of unacceptable behaviors include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Reporting Incidents
+
+At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+
+## Project Maintainer Responsibilities
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined below.
+
+## RPI-Specific Policies
+RPI-specific policies, including consequences for violating the RCOS Code of Conduct in the context of RCOS at RPI, can be found under our [Bylaws](resources/bylaws.md). Please review these if you are a student, mentor, or coordinator at RPI, as you will also be expected to follow these bylaws.
+
+## License and Attribution
+
+This Code of Conduct has been adapted with modifications from the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/). This Code of Conduct, like everything RCOS does, is open source and can be found in our [intro](https://github.com/rcos/intro) repository.

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -85,10 +85,11 @@ Whether you're completely new to programming or you feel ready to tackle advance
 
 [Ladies Storm Hackathons](https://github.com/Ladies-Storm-Hackathons)
 
-
 [Geek Feminism](http://geekfeminism.wikia.com/wiki/Geek_Feminism_Wiki)
 
 ## LGBTQ+ in Technology
 [Lesbians Who Tech](https://lesbianswhotech.org/about/)
+
 [Out in Tech](https://outintech.com/)
+
 [Rensselaer Pride Alliance](http://rpa.union.rpi.edu/)

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -1,5 +1,5 @@
 # Helpful Resources
-
+Whether you're completely new to programming or you feel ready to tackle advanced topics like deep learning, we have plenty of resources! In addition to consulting the online resources, feel free to reach out to mentors or coordinators as well.
 ## Open Source
 
 [Intro to Open Source Class Materials](https://github.com/rcos/CSCI2963-01-Spring2017)
@@ -7,6 +7,8 @@
 [Github Tutorial](https://try.github.io/levels/1/challenges/1)
 
 [Open Source Initiative](https://opensource.org/)
+
+[Mozilla Open Source Student Network](https://opensource.mozilla.community/)
 
 ## Python
 
@@ -37,3 +39,56 @@
 ## Docker
 
 [Katacoda](https://www.katacoda.com)
+
+## LaTeX
+[ShareLatex](https://www.sharelatex.com/)
+
+[LaTeX Wikibooks](https://en.wikibooks.org/wiki/LaTeX)
+
+## Data Science, Mathematical Computing
+[NumPy/SciPy stack](https://docs.scipy.org/doc/numpy-1.14.0/reference/)
+
+[Pandas (Python)](https://pandas.pydata.org/)
+
+[R](https://www.datamentor.io/r-programming)
+
+[Online Data Science Courses](https://medium.freecodecamp.org/i-ranked-all-the-best-data-science-intro-courses-based-on-thousands-of-data-points-db5dc7e3eb8e)
+
+## AI and Machine Learning
+[TensorFlow Tutorials](https://www.tensorflow.org/tutorials/)
+
+[Curated List of AI and Machine Learning Resources](https://medium.com/machine-learning-in-practice/my-curated-list-of-ai-and-machine-learning-resources-from-around-the-web-9a97823b8524)
+
+## Hardware
+[SparkFun](https://learn.sparkfun.com/)
+
+[Adafruit](https://learn.adafruit.com/)
+
+[AllAboutCircuits](https://www.allaboutcircuits.com/)
+
+## UX
+[Usability.gov](https://www.usability.gov/)
+
+[Interaction Design Foundation](https://www.interaction-design.org/)
+
+## Public Speaking & Communication
+[Public Speaking Resources](https://github.com/vmbrasseur/Public_Speaking)
+
+[Center for Global Communication + Design](https://www.commd.rpi.edu)
+
+## Women in Technology
+[RPI SWE](http://swe.union.rpi.edu/)
+
+[RPI ACM-W](https://acmwrpi.wordpress.com/)
+
+[NCWIT](https://www.ncwit.org/)
+
+[Ladies Storm Hackathons](https://github.com/Ladies-Storm-Hackathons)
+
+
+[Geek Feminism](http://geekfeminism.wikia.com/wiki/Geek_Feminism_Wiki)
+
+## LGBTQ+ in Technology
+[Lesbians Who Tech](https://lesbianswhotech.org/about/)
+[Out in Tech](https://outintech.com/)
+[Rensselaer Pride Alliance](http://rpa.union.rpi.edu/)

--- a/docs/resources/bylaws.md
+++ b/docs/resources/bylaws.md
@@ -1,0 +1,59 @@
+# Bylaws
+
+Our Bylaws are an extension of our [Code of Conduct](resources/CODE_OF_CONDUCT.md). The Bylaws apply to RCOS meetings at RPI, including large group and small group meetings as well as bonus sessions, casual coding sessions, and any project meetings unless otherwise noted.
+
+## Attendance Codes
+Attendance codes are given during all RCOS small group, large group, and bonus sessions. When the attendance code is delivered, go to http://rcos.io, click "Attend", and enter the attendance code so you can be marked as present for the current session.
+
+As much as we value sharing and openness, we also value integrity. Thus, we ask that you do not distribute attendance codes to people who are not currently attending the session. If you are caught distributing attendance codes to people who are absent, **both your attendance code as well as the attendance code(s) you distributed to others will be nullified**.
+
+If you know in advance you will not be able to make an RCOS meeting, or unforeseen circumstances arise that make you unable to attend, please review our [Excused Absence Policy](grading/excused_absences.md) instead of attempting to enter an attendance code.
+
+## Noise
+An important part of RCOS is being able to hear from both fellow RCOS members and guest speakers. We ask that you please refrain from talking or making excessive noise while a speaker is talking as it can be disruptive to the speaker and to your peers.
+
+## During Large Group
+During our large group sessions, we have the following policies.
+
+### Presentations on Sensitive Topics (full policy TBD)
+> NOTE: this policy may be already implicit, but it may be necessary as we stray into more traditionally off-topic talks. This guideline is not set in stone, feel free to remove or revise if necessary. See comments in source code for more commentary.
+
+Please keep in mind that RCOS large group sessions are mandatory for all students currently in RCOS. Detailed and explicit discussion of sensitive, upsetting, or controversial topics without warning can create an especially hostile environment when this attendance requirement is considered. 
+
+<!--TODO: flesh out specifics of "sensitive topics".
+Preliminary list may include things like sex, violence, bigotry, drugs/alcohol, death, trauma, serious physical or mental illness, etc. However, it might be better to deal with these things on a case-by-case basis. E.g. a talk on inclusive sex education should be handled much differently than explicit and graphic discussion of pornography
+
+[//]: # (Possible options for sensitive topics shall they arise:)
+[//]: # (- Keep any mention of sensitive topics brief, respectful, and non-descript in nature)
+[//]: # (- Link to further reading on material, providing appropriate content warnings and resources for help dealing with such topics/triggers if necessary)
+[//]: # (- Consider whether talk would be more appropriate as a non-mandatory session where students can easily pick an alternate activity)
+[//]: # (- Touch base with a coordinator or faculty member to further discuss options for your talk)-->
+
+### Laptops/Mobile Devices
+RCOS likes to maintain a culture of freedom. If you choose to use your laptop or mobile device during large group presentations, you may do so as long as you are mindful of the people around you. This includes:
+
+* Muting all audio
+* Not participating in audio or video calls
+* Ensuring any material that may be visible on your screen is SFW (safe for work)
+* Keeping mobile devices on "Silent" or "Vibrate"
+* Using your device's keyboard instead of a mechanical keyboard
+
+In addition, some speakers may ask audience members to close all laptops and put away all mobile devices. If a speaker does so, please respect their request.
+
+If you absolutely must take a phone call, you can exit the lecture hall to make/take a phone call. If you need to call emergency services for any reason, you may remain in the room while you make the call.
+
+If you use assistive technology due to a documented disability or injury, or you use a medical device that may make noise or looks similar in appearance to a mobile phone or laptop, **please touch base with a faculty member ASAP**. This will remain confidential.
+
+## Consequences of Code of Conduct Violations
+If you violate the RCOS Community Code of Conduct or Bylaws, appropriate consequences will follow at the discretion of faculty. These may include:
+
+* A verbal or Slack warning from a mentor or coordinator
+* A written warning from a faculty member
+* A request to edit or delete any blog posts, code, comments, issues, pull requests, milestones, wiki pages, social media posts, etc. that violate the Code of Conduct
+* If your large group talk or bonus session violates the Code of Conduct, your talk may be ended early and your slides will not be published to the #slides channel.
+* If the violation occurred at an RCOS event or meeting, you may be removed from the event or meeting. This will be marked as an unexcused absence regardless of whether or not you already entered an attendance code, and you will not be able to make up this absence by attending a bonus session.
+* In severe and repeated violations, you may be removed from RCOS entirely. 
+  * If you are taking RCOS for credit, you will receive a failing grade for the semester. 
+  * If you are currently a mentor, your mentorship position will be terminated immediately and you will be ineligible to mentor in future semesters. The same rule applies to coordinators.
+
+Please note that the above list is not exhaustive and additional consequences may follow as appropriate.

--- a/docs/resources/bylaws.md
+++ b/docs/resources/bylaws.md
@@ -18,7 +18,7 @@ During our large group sessions, we have the following policies.
 ### Presentations on Sensitive Topics (full policy TBD)
 > NOTE: this policy may be already implicit, but it may be necessary as we stray into more traditionally off-topic talks. This guideline is not set in stone, feel free to remove or revise if necessary. See comments in source code for more commentary.
 
-Please keep in mind that RCOS large group sessions are mandatory for all students currently in RCOS. Detailed and explicit discussion of sensitive, upsetting, or controversial topics without warning can create an especially hostile environment when this attendance requirement is considered. 
+Please keep in mind that RCOS large group sessions are mandatory for all students currently in RCOS. Presentations containing detailed discussion of sensitive, upsetting, or controversial topics without warning can create an especially hostile environment when this attendance requirement is considered. 
 
 <!--TODO: flesh out specifics of "sensitive topics".
 Preliminary list may include things like sex, violence, bigotry, drugs/alcohol, death, trauma, serious physical or mental illness, etc. However, it might be better to deal with these things on a case-by-case basis. E.g. a talk on inclusive sex education should be handled much differently than explicit and graphic discussion of pornography


### PR DESCRIPTION
**Resolves Issue:** #4, #5, #6, #7
**Changes in this pull request**:
- Split Code of Conduct and Bylaws, moving all RPI specific policies to bylaws
- Add more resources
- Start excused absence documentation
- Add stuff to rubric
- Add "Presentations on Sensitive Topics" to Bylaws