### PR TITLE
Refine definition of harassment

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -55,6 +55,7 @@
 * Student Resources
   * [Code Of Conduct](resources/CODE_OF_CONDUCT.md)
     * [Bylaws](resources/bylaws.md)
+    * [Anti-Harassment Guidelines](resources/harassment_guidelines.md)
   * [Presentation Slides](resources/slides.md)
   * [Resources](resources/README.md)
   * [Code Of Conduct Template](resources/code_of_conduct_template.md)

--- a/docs/resources/CODE_OF_CONDUCT.md
+++ b/docs/resources/CODE_OF_CONDUCT.md
@@ -27,20 +27,22 @@ Examples of unacceptable behaviors include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+* Public or private harassment as defined [here](resources/harassment_guidelines)
 * Publishing others’ private information, such as a physical or electronic address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Reporting Incidents
 
-At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+At any point, you may report instances of CoC violations to our [coordinators](https://rcos.github.io/rcos-handbook/#/coordinating/README) and [faculty advisors]() at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+
+If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via our [Slack](https://rcos.slack.com/).
 
 ## Project Maintainer Responsibilities
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined below.
 
 ## RPI-Specific Policies
-RPI-specific policies, including consequences for violating the RCOS Code of Conduct in the context of RCOS at RPI, can be found under our [Bylaws](resources/bylaws.md). Please review these if you are a student, mentor, or coordinator at RPI, as you will also be expected to follow these bylaws.
+RPI-specific policies, including consequences for violating the RCOS Code of Conduct in the context of RCOS at RPI, can be found under our [Bylaws](https://rcos.github.io/rcos-handbook/#/resources/bylaws). Please review these if you are a student, mentor, or coordinator at RPI, as you will also be expected to follow these bylaws.
 
 ## License and Attribution
 
-This Code of Conduct has been adapted with modifications from the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/). This Code of Conduct, like everything RCOS does, is open source and can be found in our [intro](https://github.com/rcos/intro) repository.
+This Code of Conduct has been adapted with modifications from the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/). This Code of Conduct, like everything RCOS does, is open source and can be found in our [rcos-handbook](https://github.com/rcos/rcos-handbook) repository.

--- a/docs/resources/code_of_conduct_template.md
+++ b/docs/resources/code_of_conduct_template.md
@@ -1,11 +1,10 @@
 # [Your Project] Code of Conduct
 In the interest of fostering an open and welcoming environment, [your project] pledges to be an inclusive and harassment-free experience for  all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, educational background, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-## General
-The General Code of Conduct applies to all [your project]-affiliated activity online and offline.
+This Code of Conduct applies to all [your project]-affiliated activity online and offline.
 
-### Guidelines
-#### Be respectful and inclusive
+## Guidelines
+### Be respectful and inclusive
 * **Use inclusive language.**  This includes:
   * using [gender-neutral or non-gendered language](http://geekfeminism.wikia.com/wiki/Nonsexist_language) where possible
   * when referring to community members, using their preferred pronouns
@@ -16,32 +15,34 @@ The General Code of Conduct applies to all [your project]-affiliated activity on
   * Being understanding of cultural differences
   * Making sure your project and any physical spaces your project team may meet are accessible to all members, including members with disabilities
 
-#### Give and be welcoming to constructive feedback
+### Give and be welcoming to constructive feedback
 * **Be constructive and respectful** when giving others feedback. This includes:
   * Only giving feedback when solicited (e.g. mock presentation, questions section of presentation, request for code review, pull request, etc.)
   * Keeping all feedback constructive, objective and impersonal
 
 
-### Unacceptable Behaviors
+## Unacceptable Behaviors
 
 Examples of unacceptable behaviors include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+* Public or private harassment as defined [here](https://rcos.github.io/rcos-handbook/#/resources/harassment_guidelines)
 * Publishing others’ private information, such as a physical or electronic address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
-### Reporting Incidents
+## Reporting Incidents
 
-This project is affiliated with [Rensselaer Center for Open Source](http://rcos.io) (RCOS). At any point, you may report instances of CoC violations to RCOS faculty at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
+This project is affiliated with [Rensselaer Center for Open Source](http://rcos.io) (RCOS). At any point, you may report instances of CoC violations to the RCOS [coordinators](https://rcos.github.io/rcos-handbook/#/coordinating/README) and [faculty advisors]() at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
 
-### Project Maintainer Responsibilities
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined in the RCOS Community Code of Conduct, which can be found under "License and Attribution".
+If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via the RCOS [Slack](https://rcos.slack.com/).
+
+## Project Maintainer Responsibilities
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined in the RCOS [Bylaws](https://rcos.github.io/rcos-handbook/#/resources/bylaws).
 
 ## [Your Project]-Specific Guidelines
 Add any additional ground rules you would like your project team to follow (if any) here.
 
 ## License and Attribution
 
-This Code of Conduct has been abbreviated and adapted from the [RCOS Community Code of Conduct](https://github.com/rcos/intro/blob/master/docs/code_of_conduct.md).
+This Code of Conduct has been adapted from the [RCOS Community Code of Conduct](https://github.com/rcos/intro/blob/master/docs/code_of_conduct.md).

--- a/docs/resources/harassment_guidelines.md
+++ b/docs/resources/harassment_guidelines.md
@@ -1,0 +1,30 @@
+# Harassment
+
+Our Code of Conduct prohibits "public or private harassment". For our purposes, harassment includes, but is not limited to:
+- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+- Deliberate misgendering or use of ‘dead’ or rejected names
+- Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate
+- Physical contact and simulated physical contact (eg, textual descriptions like `*hug*` or `*backrub*`) without consent or after a request to stop.
+- Threats of violence
+- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Deliberate intimidation
+- Stalking or following
+- Harassing photography or recording, including logging online activity for harassment purposes
+- Sustained disruption of discussion or talks
+- Unwelcome sexual attention
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+- Continued one-on-one communication after requests to cease
+- Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other RCOS community members or other vulnerable people from intentional abuse
+- Publication of non-harassing private communication
+- Encouraging or inciting others to violate our Code of Conduct
+
+RCOS maintains the standard that all members are should feel safe and comfortable. Our coordinators reserve the right not to act on complaints regarding:
+
+- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+- Communicating in a ‘tone’ you don’t find congenial
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+
+# License and Attribution
+This anti-harassment policy is based on the [example policy](http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy) from the Geek Feminism wiki, created by the Geek Feminism community.


### PR DESCRIPTION
**Resolves Issue:**
"Public or private harassment" isn't very well defined in the code of conduct. Although we haven't had any issues with harassment, we should have this to refer to and to make expectations clearer

**Changes in this pull request**:
- Add Harassment Guidelines separate from Code of Conduct, allowing the CoC to remain brief and decoupled from RPI specific stuff
- Revise project Code of Conduct template