### PR TITLE
Add mentor training documentation, fix alt text

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/rcos/rcos-branding/master/img/lockup-red.png" width="400px">
+<img src="https://raw.githubusercontent.com/rcos/rcos-branding/master/img/lockup-red.png" width="400px" alt="RCOS - Rensselaer Center for Open Source">
 
 <hr style='width:40%; border-color:#da291c;'>
 <h1 style="color: #da291c">Handbook</h1>

--- a/docs/mentoring/training.md
+++ b/docs/mentoring/training.md
@@ -1,3 +1,62 @@
 # Mentor Training
 
-TODO - define mentor training procedure here
+## Overview
+- Proposed timeslots 
+- Topics to cover
+
+## Mentor Training Event(s)
+Welcome to the RCOS mentor team! At the beginning of each semester, we hold mentor training sessions to help get our new mentors started.
+
+Our training sessions for Fall 2018 will occur on the following dates and times in [location TBD]:
+<!-- 
+Ideally, we should have at least one timeslot on or after August 27th since that is the earliest time that upperclassmen residence halls/on campus apartments open. 
+However, we should ideally host our training session before our first large group or before our second large group (Tuesday) at the very latest. 
+-->
+  - TBD 
+
+If you are unable to physically attend the session(s), Hangouts links will be provided.
+
+## Topics Covered in Mentor Training
+Below is a rough outline of what will be covered in the training sessions.
+
+### Estimated Time Commitments
+Bare minimum:
+  - **Mentor training**: mandatory for all first-time mentors, optional for returning mentors (returning mentors may help facilitate training and/or answer any questions)
+  - **Small group**: ~1-2 hours weekly (usually on Tuesdays)
+  - **Large group**: ~1-2 hours weekly
+  - **Mentor meetings**: biweekly, typically no longer than 30 mins-1 hour
+
+You may also be expected to help with casual coding sessions, bonus sessions, and/or code jams. 
+
+### First Two Weeks
+The first two weeks agenda can be found [here](coordinating/agenda). 
+
+As a mentor, you are expected to help out with proposal review and/or project speed dating. If you have a course conflict on Tuesdays at 4pm (e.g. ECSE seminar), please let the coordinators know so that:
+  - your absence during these meetings can be marked as excused
+  - you can be placed in an alternate small group (typically held at 6pm on Tuesday)
+
+### Using Observatory as a Mentor
+  - Verification
+  - Setting up a small group
+  - Generating small group attendance codes
+
+### Running Small Group
+A brief overview of small group meetings for RCOS members can be found [here](events/small_group_meetings). Mentor training will additionally cover:
+  - Running standup
+  - Reviewing presentations <!-- really emphasize presentation review this semester --> 
+
+### Helping in Large Group
+  - Managing noise levels/talking
+  - Verifying members
+
+### Handling Code of Conduct Violations
+Please familiarize yourselves with our [Code of Conduct](resources/CODE_OF_CONDUCT) and [Bylaws](resources/bylaws). As a mentor, you are not only expected to follow these, but to enforce them where appropriate. 
+
+Any violations warranting more than a verbal/Slack warning (e.g. repeated offenses, harassment) should be reported to coordinators/faculty advisors, who will then determine the appropriate action(s) necessary.
+
+<!-- 
+TODO: flesh this out further 
+Example enforcing manuals: 
+Ada Initiative template: http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports
+Django project enforcement manual: https://www.djangoproject.com/conduct/enforcement-manual/
+-->


### PR DESCRIPTION
**Resolves Issue:** #38, #32 
**Changes in this pull request**:
- Start mentor training documentation, TODO flesh out dates for training
- Add alt text to logo
