### PR TITLE
Add current info on excused absences, mentor training

### DIFF
--- a/docs/grading/attendance.md
+++ b/docs/grading/attendance.md
@@ -35,5 +35,12 @@ The above list is not exhaustive. If you are unsure about what constitutes an ex
 
 Excused absences do **not** need to be made up with a bonus session (but you are encouraged to come to bonus sessions regardless!).
 
-## How to Request an Excused Absence on Observatory
-This feature is coming soon!
+### Requesting Excused Absences
+
+Currently, in order to request an excused absence, you must contact a coordinator or faculty advisor.
+
+In the future, functionality will be implemented to request excused absences through Observatory!
+
+## Resolving Attendance Issues
+
+**TODO**: See [issue #66](https://github.com/rcos/rcos-handbook/issues/66) on our Github repository.

--- a/docs/mentoring/training.md
+++ b/docs/mentoring/training.md
@@ -28,7 +28,7 @@ You may also be expected to help with casual coding sessions, bonus sessions, an
 ### First Two Weeks
 The first two weeks agenda can be found [here](coordinating/agenda). 
 
-As a mentor, you are expected to help out with proposal review and/or project speed dating. If you have a course conflict on Tuesdays at 4pm (e.g. ECSE seminar), please let the coordinators know so that:
+As a mentor, you are expected to help out with project speed dating. If you have a course conflict on Tuesdays at 4pm (e.g. ECSE seminar), please let the coordinators know so that:
   - your absence during these meetings can be marked as excused
   - you can be placed in an alternate small group (typically held at 6pm on Tuesday)
 

--- a/docs/mentoring/training.md
+++ b/docs/mentoring/training.md
@@ -7,15 +7,6 @@
 ## Mentor Training Event(s)
 Welcome to the RCOS mentor team! At the beginning of each semester, we hold mentor training sessions to help get our new mentors started.
 
-Our training sessions for Fall 2018 will occur on the following dates and times in [location TBD]:
-<!-- 
-Ideally, we should have at least one timeslot on or after August 27th since that is the earliest time that upperclassmen residence halls/on campus apartments open. 
-However, we should ideally host our training session before our first large group or before our second large group (Tuesday) at the very latest. 
--->
-  - TBD 
-
-If you are unable to physically attend the session(s), Hangouts links will be provided.
-
 ## Topics Covered in Mentor Training
 Below is a rough outline of what will be covered in the training sessions.
 

--- a/docs/mentoring/training.md
+++ b/docs/mentoring/training.md
@@ -1,11 +1,17 @@
 # Mentor Training
 
 ## Overview
-- Proposed timeslots 
 - Topics to cover
+- Slides
 
 ## Mentor Training Event(s)
 Welcome to the RCOS mentor team! At the beginning of each semester, we hold mentor training sessions to help get our new mentors started.
+
+Mentor training is required for all new mentors and returning mentors who have not mentored in at least 2 semesters and did not complete mentor training prior to becoming a mentor.
+
+All other returning mentors are not required to attend mentor training, but are welcome to assist the coordinators in facilitating mentor training.
+
+External mentors are not required to complete mentor training, but are encouraged to review the mentor training slides.
 
 ## Topics Covered in Mentor Training
 Below is a rough outline of what will be covered in the training sessions.
@@ -54,3 +60,7 @@ Django project enforcement manual: https://www.djangoproject.com/conduct/enforce
 
 ### Q&A
 Current mentors and coordinators will be present at each training event to answer any questions you may have about mentorship.
+
+## Mentor Training Slides
+
+The mentor training slides can be accessed in [our presentations repository](https://github.com/rcos/presentations/tree/master/mentor-training) (source code) and online at [https://rcos.github.io/presentations/mentor-training/](https://rcos.github.io/presentations/mentor-training/)  (compiled presentation).


### PR DESCRIPTION
**Resolves Issue:** #63, TBD in mentor training 

**Changes in this pull request**:
- Get rid of TBD info in mentor training
- Clarify who is required to attend
- Add up-to-date info on requesting excused absences 