### PR TITLE
Added link to TLDRLegal in docs/resources

### DIFF
--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -3,7 +3,9 @@ Whether you're completely new to programming or you feel ready to tackle advance
 
 ## Open Source
 
-[Intro to Open Source Class Materials](https://github.com/rcos/CSCI2963-01-Spring2017)
+[TLDRLegal - Software Licenses in Plain English](https://tldrlegal.com/)
+
+[Intro to Open Source Course Materials](https://github.com/rcos/CSCI2963-01-Spring2017)
 
 [GitHub Tutorial](https://try.github.io/levels/1/challenges/1)
 


### PR DESCRIPTION
**Resolves Issue:** N/A

**Changes in this pull request**:
- Added a link to [TLDRLegal](https://tldrlegal.com/) in student resources section
