### PR TITLE
slack mentions/urls -> mattermost mentions/urls

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ Examples of unacceptable behaviors include:
 
 At any point, you may report instances of CoC violations to our [coordinators](https://rcos.github.io/rcos-handbook/#/coordinating/README) and [faculty advisors](https://handbook.rcos.io/#/coordinating/faculty) at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
 
-If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via our [Slack](https://rcos.slack.com/).
+If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via our [Mattermost](https://chat.rcos.io/).
 
 ## Project Maintainer Responsibilities
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined below.

--- a/docs/community/CODE_OF_CONDUCT.md
+++ b/docs/community/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ Examples of unacceptable behaviors include:
 
 At any point, you may report instances of CoC violations to our [coordinators](https://rcos.github.io/rcos-handbook/#/coordinating/README) and [faculty advisors](https://handbook.rcos.io/#/coordinating/faculty) at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
 
-If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via our [Slack](https://rcos.slack.com/).
+If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via our [Mattermost](https://chat.rcos.io/).
 
 ## Project Maintainer Responsibilities
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined below.

--- a/docs/community/bylaws.md
+++ b/docs/community/bylaws.md
@@ -63,7 +63,7 @@ If you violate the RCOS Community Code of Conduct or Bylaws, appropriate consequ
 
 ### Short Version
 Consequences may include:
-- Verbal, Slack, or written warnings
+- Verbal, Mattermost, or written warnings
 - Requests to edit or delete project material
 - Removal from sessions
 - Grade penalties
@@ -79,7 +79,7 @@ See the long version below for details on what these penalties entail.
 
 Consequences may include:
 
-* A verbal or Slack warning from a mentor or coordinator
+* A verbal or Mattermost warning from a mentor or coordinator
 * A written warning from a faculty advisor
 * A request to edit or delete any project material that violates the Code of Conduct 
   * Project material includes, but is not limited to, status updates, blog posts, code, comments, issues, pull requests, milestones, wiki pages, static websites, graphics, social media posts, etc. 

--- a/docs/community/code_of_conduct_template.md
+++ b/docs/community/code_of_conduct_template.md
@@ -54,7 +54,7 @@ Examples of unacceptable behaviors include:
 
 This project is affiliated with [Rensselaer Center for Open Source](http://rcos.io) (RCOS). At any point, you may report instances of CoC violations to the RCOS [coordinators](https://rcos.github.io/rcos-handbook/#/coordinating/README) and [faculty advisors](https://handbook.rcos.io/#/coordinating/faculty) at <coordinators@rcos.io>. You, as well as any other witnesses, have the right to remain anonymous to the rest of the RCOS community.
 
-If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via the RCOS [Slack](https://rcos.slack.com/).
+If you are uncomfortable reporting to the coordinators for any reason, you may reach out to a faculty advisor directly via the RCOS [Mattermost](https://chat.rcos.io/).
 
 ## Project Maintainer Responsibilities
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. In the case of contributors external to RPI and/or RCOS, temporary or permanent bans may occur. RPI-specific policies are outlined in the RCOS [Bylaws](https://rcos.github.io/rcos-handbook/#/community/bylaws).

--- a/docs/coordinating/agenda.md
+++ b/docs/coordinating/agenda.md
@@ -63,6 +63,6 @@ Projects with 8 or more members may be split between mentor groups.
 
 At least one mentor meeting excluding mentor training must occur prior to the fourth meeting. Mentors should be instructured to ensure that mentees:
 1. Are on [rcos.io](https://rcos.io).
-2. Are on [rcos.slack.com](https://rcos.slack.com)
+2. Are on [chat.rcos.io](https://chat.rcos.io)
 
 Any larger goals for the year should be made clear and a schedule for mentor meetings should be set.

--- a/docs/membership/join_rcos.md
+++ b/docs/membership/join_rcos.md
@@ -1,8 +1,8 @@
 # How to join RCOS
 
-If you're an RPI student, hop in on our first meeting of the semester or join [our slack](https://rcos.slack.com) and message a faculty coordinator (@mskmoorthy or @turnew2).
+If you're an RPI student, hop in on our first meeting of the semester or join [our mattermost](https://chat.rcos.io) and message a faculty coordinator (@mskmoorthy or @turnew2).
 
-If you're looking to get involved with RCOS as a member outside of RPI, email a [coordinator](mailto:coordinators@rcos.io) to get setup on the [rcos slack](#slack). In the meantime, you can create an account and fill in your profile on [Observatory](#observatory).
+If you're looking to get involved with RCOS as a member outside of RPI, email a [coordinator](mailto:coordinators@rcos.io) to get setup on the [rcos mattermost](#mattermost). In the meantime, you can create an account and fill in your profile on [Observatory](#observatory).
 
 <!-- RCOS is a group of RPI students who work on open source projects. Our members work on a variety of projects, which can be seen on the projects page. To see the presentation schedule look here. -->
 
@@ -22,9 +22,9 @@ If you're looking to get involved with RCOS as a member outside of RPI, email a 
 
 [Observatory](https://rcos.io) is RCOS's open source project management platform. Every RCOS member is required to have an observatory account, it's through this platform that you can write blog posts, record your attendance and see other RCOS projects.
 
-## Slack
+## Mattermost
 
-[Slack](https://rcos.slack.com) is the primary communication platform for RCOS. Each team in RCOS has a Slack channel where they can coordinate meetings and manage the project.
+[Mattermost](https://chat.rcos.io) is the primary communication platform for RCOS. Each team in RCOS has a Mattermost channel where they can coordinate meetings and manage the project.
 
 ## Git
 

--- a/docs/membership/new_projects.md
+++ b/docs/membership/new_projects.md
@@ -18,15 +18,15 @@ Once you have a proposal, if you are contributing at RPI, fill out the RPI-speci
 ## Setup
 
 If you haven't already, set up an account on:
-  - RCOS Slack
+  - RCOS Mattermost
   - Observatory
   - Github
 
-## Create a Slack channel
+## Create a Mattermost channel
 
-Once all of your team members are on the RCOS Slack, create a channel for your team to communicate. This can be done by pressing the '+' icon next to "Channels" on our Slack.
+Once all of your team members are on the RCOS Mattermost, create a channel for your team to communicate. This can be done by pressing the '+' icon next to "Channels" on our Mattermost.
 
-Don't forget to add your [small group mentors]() to your team's Slack channel so they can help you out if needed! If you haven't been assigned a small group yet, you can skip this step until you have a small group assigned.
+Don't forget to add your [small group mentors]() to your team's Mattermost channel so they can help you out if needed! If you haven't been assigned a small group yet, you can skip this step until you have a small group assigned.
 
 ## Setup Your Repository
 

--- a/docs/mentoring/README.md
+++ b/docs/mentoring/README.md
@@ -12,7 +12,7 @@ you where/how to find help for your project, and help you find a new project etc
 ### How to be a good mentor
 - Help mentees to reach their own goals
 - Talk directly to projects and mentees, understand what their project is and where you can help
-- Share ideas and contribute to development of RCOS as a whole- as long as you're monitoring the #mentors slack channel you should opportunities to contribute.
+- Share ideas and contribute to development of RCOS as a whole- as long as you're monitoring the #mentors mattermost channel you should opportunities to contribute.
 
 ### Things Mentors should Know
 - Names and channels for referring mentees to coordinators or faculty

--- a/docs/mentoring/training.md
+++ b/docs/mentoring/training.md
@@ -49,7 +49,7 @@ A brief overview of small group meetings for RCOS members can be found [here](me
 ### Handling Code of Conduct Violations
 Please familiarize yourselves with our [Code of Conduct](community/CODE_OF_CONDUCT) and [Bylaws](community/bylaws). As a mentor, you are not only expected to follow these, but to enforce them where appropriate.
 
-Any violations warranting more than a verbal/Slack warning (e.g. repeated offenses, harassment) should be reported to coordinators/faculty advisors, who will then determine the appropriate action(s) necessary.
+Any violations warranting more than a verbal/Mattermost warning (e.g. repeated offenses, harassment) should be reported to coordinators/faculty advisors, who will then determine the appropriate action(s) necessary.
 
 <!--
 TODO: flesh this out further

--- a/docs/work_groups/README.md
+++ b/docs/work_groups/README.md
@@ -24,14 +24,14 @@ If you have an idea for a new Work Group, or would like to change an existing on
 All RCOS Work Groups must meet the following requirements each semester:
 - Consist of at least one mentor (student or alumni) and one active student (2 member minimum)
 - Must not exceed more than 8 members (keeps things manageable)
-- Maintain their own dedicated Slack channel
+- Maintain their own dedicated Mattermost channel
 - Produce at least one blog post  _per-group_ per-semester summarizing their efforts
 - Meet **at least four times** during the semester as a team. Meetings may be held in-person or remotely.
 
 ### Joining a Work Group
 Work Group positions are open to all RCOS students, alumni, and faculty. Please consult the following steps to join a group:
 - Fill out the [Work Group Sign Up](__TODO - add link to Google Form__) form
-- Join the Work Group's Slack channel
+- Join the Work Group's Mattermost channel
 
 ### Leading a Work Group
 Leading a Work Group requires more responsibility than simply being a member of one. Group leaders are expected to take ownership of the following duties:

--- a/slides/intro.md
+++ b/slides/intro.md
@@ -241,7 +241,7 @@ Bonus Sessions + Workshops on a rolling basis
 
 ### Getting started at RCOS
 - Observatory
-- Slack
+- Mattermost
 - SIS
 - GitHub
 
@@ -254,8 +254,8 @@ RCOS's homebrew project management system
 
 ---
 
-### Slack
-http://rcos.slack.com
+### Mattermost
+http://chat.rcos.io
 
 RCOS's primary communication medium
 
@@ -285,7 +285,7 @@ https://rcos.io/projects
 
 ### Finding a team (optional)
 - Pitch Day
-- Post on Slack (#slides)
+- Post on Mattermost (#slides)
 - Talk to mentors and coordinators
 - Project Speed Dating
 
@@ -298,7 +298,7 @@ https://rcos.io/projects
 
 ### Getting Help
 - `#helpdesk`
-- Slack
+- Mattermost
 - Other members!
 - Mentors (Both internal and external)
 - Coordinators
@@ -340,7 +340,7 @@ https://rcos.io/projects
 ###  What happens next?
 Project pitches Tuesday!
 
-- Send your slides to @aeksco on Slack
+- Send your slides to @aeksco on Mattermost
 - Please send them by 11pm on Monday (9/4)
 - Slides MUST be in JPEG format!
 - Please NO PDF, PPT/X, or Google links!
@@ -361,7 +361,7 @@ Saturday 9/1 - 12-4pm in SAGE 4510
 ---
 
 ### What do you do now?
-- Sign up on rcos.io, Slack, and GitHub
+- Sign up on rcos.io, Mattermost, and GitHub
 - Register on SIS (`CRN 53081`, `CSCI-4963-01`)
 - Find a project
 - Email your pitch slides!
@@ -373,7 +373,7 @@ Saturday 9/1 - 12-4pm in SAGE 4510
 - Coordinators
 - Mentors
 - Faculty
-- Slack `#helpdesk`
+- Mattermost `#helpdesk`
 
 ---
 


### PR DESCRIPTION
**Resolves Issue:** (#113 #114)

**Changes in this pull request**:
- [Ss]lack -> [Mm]attermost
- rcos.slack.com -> chat.rcos.io
