### PR TITLE
Add password documentation

### DIFF
--- a/docs/coordinating/passwords.md
+++ b/docs/coordinating/passwords.md
@@ -1,3 +1,11 @@
 # Passwords
 
-> TODO - we need to establish a system for creating, storing, and re-generating passwords for `coordinators@rcos.io`, and our social media accounts. Potential solutions include [Passbolt](https://www.passbolt.com), [Psono](https://psono.com/), or [BitWarden](https://bitwarden.com/).
+It is imperative that RCOS infrastructure and social media accounts are always accessible to Coordinators and Faculty Advisors from a secure, centralized location. We currently use [BitWarden](https://vault.bitwarden.com/#/vault) for this.
+
+### Access to BitWarden Vault
+
+Coordinators must be securely sent the username and password combination to the BitWarden account upon becoming a coordinator. This account grants access to all other RCOS accounts so naturally it must be kept extremely secure.
+
+### New RCOS Accounts
+
+Coordinators in the past used personal accounts for RCOS infrastructure. Once they graduated, succeeding Coordinators lost access and sometimes even knowledge of those important accounts. Therefore, it is imperative that **personal accounts are NEVER used for RCOS infrastructure or social media** but instead use the `rcos.management@gmail.com` email and are added to the RCOS BitWarden vault.


### PR DESCRIPTION
**Changes in this pull request**:
- Replace TODOs with password documentation
- Explain use of BitWarden
- Prohibit using personal accounts for RCOS infrastructure/social media
