### PR TITLE
Fix sidebar on mobile

### DIFF
--- a/docs/theme.css
+++ b/docs/theme.css
@@ -560,7 +560,6 @@ section.cover .cover-main {
     flex: 1;
     margin: -20px 16px 0;
     text-align: center;
-    z-index: 1
 }
 
 section.cover a {


### PR DESCRIPTION
If you open the sidebar on a mobile device or very small screen the sidebar will conflict with the content as shown below. This PR fixes it so it properly overlays on mobile.

### Before fix:
![image](https://user-images.githubusercontent.com/55092742/171322387-4b25fe50-8180-469e-b113-4904aff89ef8.png)

### After fix:
![image](https://user-images.githubusercontent.com/55092742/171322422-cf3318e0-5386-47d6-bfe8-62e35e6575b0.png)
